### PR TITLE
[10.0] force update of setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git config --global user.email "root@localhost" && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install --upgrade setuptools==39.0.1 && \
+RUN pip install setuptools==39.0.1 && \
     pip install pip==9.0.1 wheel==0.30.0
 
 COPY docker_files/extended_entrypoint.sh \


### PR DESCRIPTION
Force the update of setuptools to prevent failing image build such as:

https://quay.io/repository/numigi/odoo-public/build/382859a2-94f3-4f14-8f29-d42a0d3cd6f4