### PR TITLE
Add base_view_inheritance_extension

### DIFF
--- a/gitoo.yml
+++ b/gitoo.yml
@@ -18,6 +18,7 @@
 - url: https://github.com/oca/server-tools
   branch: "12.0"
   patches:
+    # PR: https://github.com/OCA/server-tools/pull/1529
     - url: https://github.com/akretion/server-tools
       branch: 12.0-mig-base_view_inheritance_extension
       commit: 61a83bb372dc83d6344993034ad0ee6123846d53

--- a/gitoo.yml
+++ b/gitoo.yml
@@ -14,3 +14,12 @@
     - url: https://github.com/numigi/odoo
       branch: 12.0-fix-stock-inventory-title
       commit: c66c510842efc4c8d9447f5b929926b39831a37a
+
+- url: https://github.com/oca/server-tools
+  branch: "12.0"
+  patches:
+    - url: https://github.com/akretion/server-tools
+      branch: 12.0-mig-base_view_inheritance_extension
+      commit: 61a83bb372dc83d6344993034ad0ee6123846d53
+  includes:
+    - base_view_inheritance_extension


### PR DESCRIPTION
This module from OCA solves a major missing feature in view inheritance.
It allows to add key-value pairs to the context of a view node.
https://numigi.com/web#id=18759&action=298&model=project.task&view_type=form&menu_id=200