### PR TITLE
Completely override the entrypoint from odoo:12.0 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,14 +14,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN pip3 install pip==18.0 wheel==0.32.1
 
-COPY docker_files/extended_entrypoint.sh \
-    docker_files/requirements.txt \
-    gitoo.yml \
-    gitoo-addons.yml \
-    /
-COPY patches patches
-
+COPY docker_files/requirements.txt /
 RUN pip3 install -r /requirements.txt && rm /requirements.txt
+
+COPY gitoo.yml gitoo-addons.yml /
+COPY patches patches
 
 ENV ODOO_DIR /usr/lib/python3/dist-packages/
 RUN gitoo install-all --conf_file /gitoo.yml --destination "${ODOO_DIR}"
@@ -38,8 +35,9 @@ COPY ./.coveragerc .
 
 COPY docker_files/odoo.conf docker_files/odoo_specific.conf /etc/odoo/
 
-RUN chmod +x /extended_entrypoint.sh
-ENTRYPOINT ["/extended_entrypoint.sh"]
+COPY docker_files/entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["odoo"]
 EXPOSE 8069 8071
 USER odoo

--- a/docker_files/entrypoint.sh
+++ b/docker_files/entrypoint.sh
@@ -18,4 +18,10 @@ if [[ "${wait_for_db_host}" = true ]] ; then
     done
 fi
 
-exec /entrypoint.sh "$@"
+case "$1" in
+    -- | -*)
+        exec odoo "$@"
+        ;;
+    *)
+        exec "$@"
+esac


### PR DESCRIPTION
The entrypoint.sh of the odoo:12.0 image parses the odoo.conf directly in bash.
This logic is complex and incompatible with the specific conf feature implemented in odoo-public.

https://www.numigi.com/web#id=19569&view_type=form&model=project.task&menu_id=200