### PR TITLE
TA#20752 11.0 fix pg client

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,10 +8,6 @@ gitoo_install_odoo: &gitoo_install_odoo
   name: Gitoo install
   command: ./gitoo-install-odoo.sh
 
-gitoo_install_extra_addons: &gitoo_install_extra_addons
-  name: Gitoo install extra addons
-  command: ./gitoo-install-addons.sh
-
 deploy_docker_build: &deploy_docker_build
   name: Docker build
   command: docker build --build-arg GIT_TOKEN=${GIT_TOKEN}  --rm --pull -t "${DOCKER_IMAGE_NAME}" .
@@ -32,8 +28,6 @@ jobs:
 
        - run:
           <<: *gitoo_install_odoo
-       - run:
-          <<: *gitoo_install_extra_addons
 
        - run:
           name: Build -- Init Database
@@ -62,8 +56,6 @@ jobs:
        - run:
           <<: *gitoo_install_odoo
        - run:
-          <<: *gitoo_install_extra_addons
-       - run:
           name: Set DOCKER_IMAGE_NAME env variable to odoo-public
           command: |
             echo 'export DOCKER_IMAGE_NAME="quay.io/${CIRCLE_PROJECT_USERNAME,,}/${CIRCLE_PROJECT_REPONAME,,}:${CIRCLE_TAG}"' >> $BASH_ENV
@@ -82,8 +74,6 @@ jobs:
           <<: *quay_io_login
       - run:
           <<: *gitoo_install_odoo
-      - run:
-          <<: *gitoo_install_extra_addons
       - run:
           name: Set DOCKER_IMAGE_NAME env variable to odoo-public
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ quay_io_login: &quay_io_login
   name: Login to Quay.io register
   command: docker login quay.io -u "${QUAY_USER}" -p "${QUAY_TOKEN}"
 
-gitoo_install: &gitoo_install
+gitoo_install_odoo: &gitoo_install_odoo
   name: Gitoo install
   command: ./gitoo-install-odoo.sh
 
@@ -31,7 +31,9 @@ jobs:
           command: sudo mkdir -p ./log && sudo chmod 777 ./log
 
        - run:
-          <<: *gitoo_install
+          <<: *gitoo_install_odoo
+       - run:
+          <<: *gitoo_install_extra_addons
 
        - run:
           name: Build -- Init Database

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN set -x; \
         && gpgconf --kill all \
         && rm -rf "$GNUPGHOME" \
         && apt-get update  \
-        && apt-get install --no-install-recommends postgresql-client \
+        && apt-get install --no-install-recommends -y postgresql-client \
         && rm -rf /var/lib/apt/lists/*
 
 # Install rtlcss (copied from the official odoo image)

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,22 @@ RUN set -x; \
         && gpgconf --kill all \
         && rm -rf "$GNUPGHOME" \
         && apt-get update  \
-        && apt-get install --no-install-recommends -y postgresql-client-9.6 \
+        && apt-get install --no-install-recommends postgresql-client \
         && rm -rf /var/lib/apt/lists/*
+
+# Install rtlcss (copied from the official odoo image)
+RUN set -x;\
+    echo "deb http://deb.nodesource.com/node_8.x stretch main" > /etc/apt/sources.list.d/nodesource.list \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && repokey='9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280' \
+    && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "${repokey}" \
+    && gpg --batch --armor --export "${repokey}" > /etc/apt/trusted.gpg.d/nodejs.gpg.asc \
+    && gpgconf --kill all \
+    && rm -rf "$GNUPGHOME" \
+    && apt-get update \
+    && apt-get install -y nodejs \
+    && npm install -g rtlcss \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN git config --global user.name "Odoo" && \
     git config --global user.email "root@localhost"


### PR DESCRIPTION
Install the last version of postgresql-client instead of version 9.6.
Otherwise, a pg dump created from a more recent version is not readable.

Also install rtlcss.