### PR TITLE
TA#20752 Fix postgresql-client version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN set -x; \
         && gpgconf --kill all \
         && rm -rf "$GNUPGHOME" \
         && apt-get update  \
-        && apt-get install --no-install-recommends postgresql-client \
+        && apt-get install --no-install-recommends -y postgresql-client \
         && rm -rf /var/lib/apt/lists/*
 
 # Install rtlcss (copied from the official odoo image)

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,22 @@ RUN set -x; \
         && gpgconf --kill all \
         && rm -rf "$GNUPGHOME" \
         && apt-get update  \
-        && apt-get install --no-install-recommends -y postgresql-client-9.6 \
+        && apt-get install --no-install-recommends postgresql-client \
         && rm -rf /var/lib/apt/lists/*
+
+# Install rtlcss (copied from the official odoo image)
+RUN set -x;\
+    echo "deb http://deb.nodesource.com/node_8.x stretch main" > /etc/apt/sources.list.d/nodesource.list \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && repokey='9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280' \
+    && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "${repokey}" \
+    && gpg --batch --armor --export "${repokey}" > /etc/apt/trusted.gpg.d/nodejs.gpg.asc \
+    && gpgconf --kill all \
+    && rm -rf "$GNUPGHOME" \
+    && apt-get update \
+    && apt-get install -y nodejs \
+    && npm install -g rtlcss \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN git config --global user.name "Odoo" && \
     git config --global user.email "root@localhost"


### PR DESCRIPTION
Install the last version of postgresql-client instead of version 9.6.
Otherwise, a pg dump created from a more recent version is not readable.

Also install rtlcss.