### PR TITLE
Remove patch 12.0-fix_pivot_view_strings

### DIFF
--- a/gitoo.yml
+++ b/gitoo.yml
@@ -1,6 +1,6 @@
 - url: https://github.com/odoo/odoo
   branch: "12.0"
-  commit: 3050100eeaaede6aa4a6f17fd9e7ae04cccd9090
+  commit: eac547c7cac3e1a9fb1bb8934a1e801522a9d498
   base: true
   patches:
     - file: patches/enable-specific-conf.patch

--- a/gitoo.yml
+++ b/gitoo.yml
@@ -5,11 +5,6 @@
   patches:
     - file: patches/enable-specific-conf.patch
 
-    # PR: https://github.com/odoo/odoo/pull/35078
-    - url: https://github.com/numigi/odoo
-      branch: 12.0-fix_pivot_view_strings
-      commit: fb11493d9a7f34e1fb155899271666eb54a8708e
-
     # PR: https://github.com/odoo/odoo/pull/41663
     - url: https://github.com/numigi/odoo
       branch: 12.0-fix-stock-inventory-title

--- a/gitoo.yml
+++ b/gitoo.yml
@@ -1,6 +1,6 @@
 - url: https://github.com/odoo/odoo
   branch: "12.0"
-  commit: eac547c7cac3e1a9fb1bb8934a1e801522a9d498
+  commit: 5d99785cfbd76bbf200fab228cbc9c14d6f44c07
   base: true
   patches:
     - file: patches/enable-specific-conf.patch


### PR DESCRIPTION
The code was fixed at https://github.com/odoo/odoo/commit/0cfc913e69213a5832b3cbf79e1df8d344a28c23.